### PR TITLE
Fixed NoteMapper accessing the wrong Table

### DIFF
--- a/lib/Db/NoteMapper.php
+++ b/lib/Db/NoteMapper.php
@@ -10,7 +10,7 @@ use OCP\IDBConnection;
 class NoteMapper extends QBMapper {
 
     public function __construct(IDBConnection $db) {
-        parent::__construct($db, 'notestutorial', Note::class);
+        parent::__construct($db, 'notes_meta', Note::class);
     }
 
 	/**
@@ -24,7 +24,7 @@ class NoteMapper extends QBMapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
-			->from('notestutorial')
+			->from('notes_meta')
 			->where($qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT)))
 			->andWhere($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
 		return $this->findEntity($qb);
@@ -38,7 +38,7 @@ class NoteMapper extends QBMapper {
 		/* @var $qb IQueryBuilder */
 		$qb = $this->db->getQueryBuilder();
 		$qb->select('*')
-			->from('notestutorial')
+			->from('notes_meta')
 			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
 		return $this->findEntities($qb);
     }


### PR DESCRIPTION
NoteMapper uses the Table "notestutorial" while the Migration class uses the Table "notes_meta".
They are now both using the Table "notes_meta"