### PR TITLE
Reduce the scope of stylelint so 3rdparty libs are not modified 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "optimize-autoloader": true,
         "classmap-authoritative": true,
         "platform": {
-			"php": "7.2"
-		}
+            "php": "7.2"
+        }
     },
     "scripts": {
         "lint": "find . -name \\*.php -not -path './vendor/*' -not -path './build/*' -print0 | xargs -0 -n1 php -l",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
 		"watch": "NODE_ENV=development webpack --progress --watch --config webpack.js",
 		"lint": "eslint --ext .js,.vue src",
 		"lint:fix": "eslint --ext .js,.vue src --fix",
-		"stylelint": "stylelint **/*.css **/*.scss **/*.vue",
-		"stylelint:fix": "stylelint **/*.css **/*.scss **/*.vue --fix"
+		"stylelint": "stylelint css/*.css css/*.scss src/**/*.scss src/**/*.vue",
+		"stylelint:fix": "stylelint css/*.css css/*.scss src/**/*.scss src/**/*.vue --fix"
 	},
 	"dependencies": {
 		"@nextcloud/axios": "^1.4.0",


### PR DESCRIPTION
I think it's better to also limit this in this tutorial, so people can copy the stylelint config without `stylelint:fix` modifying all their dependencies.