### PR TITLE
Set minimum nextcloud version to 25 as required by `@nextcloud/vue` 7.x

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,14 +5,14 @@
     <name>Notes Tutorial</name>
     <summary>App for taking notes</summary>
     <description><![CDATA[This is a tutorial app for taking notes to demonstrate the Nextcloud API]]></description>
-    <version>18.0.0</version>
+    <version>20.0.0</version>
     <licence>agpl</licence>
     <author mail="dev@bernhard-posselt.com" >Bernhard Posselt</author>
     <namespace>NotesTutorial</namespace>
     <category>office</category>
     <bugs>https://github.com/nextcloud/app-tutorial</bugs>
     <dependencies>
-        <nextcloud min-version="21" max-version="24"/>
+        <nextcloud min-version="25" max-version="25"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "notestutorial",
   "description": "A simple Nextcloud app tutorial for building a notes app",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "author": "Julius Härtl <jus@bitgrid.net",
   "contributors": [
     "John Molakvoæ <skjnldsv@protonmail.com>"


### PR DESCRIPTION
(and also increase maximum version to 25, so this can be used with latest nextcloud version)