### PR TITLE
fix: id of content to be unique

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -1,1 +1,8 @@
-<div id="content"></div>
+<!--
+This is an empty template on purpose.
+Nextcloud server renders it inside the default layout
+in the <main id="content"> tag.
+
+The vue app created in src/main.js replaces the main tag.
+Therefore any content provided here will be overwritten.
+-->


### PR DESCRIPTION
`content` is already used as an id in the server template: https://github.com/nextcloud/server/blob/c10317f7f9f53a4de464915f754896eed7f1ee6c/core/templates/layout.user.php#L125

Make sure to have a unique id and to replace the correct dom element when mounting the vue app.

Fixes #474.